### PR TITLE
[feat] 아티클 뷰 구현

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,6 +78,9 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1'
     implementation 'com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:1.0.0'
 
+    // flexboxManager
+    implementation 'com.google.android.flexbox:flexbox:3.0.0'
+
     implementation 'androidx.core:core-ktx:1.8.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.5.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
         tools:targetApi="31">
         <activity
             android:name=".presentation.article.ArticleActivity"
-            android:exported="false"
+            android:exported="true"
             android:screenOrientation="portrait" />
         <activity
             android:name=".presentation.MainActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,10 @@
         android:usesCleartextTraffic="true"
         tools:targetApi="31">
         <activity
+            android:name=".presentation.article.ArticleActivity"
+            android:exported="false"
+            android:screenOrientation="portrait" />
+        <activity
             android:name=".presentation.MainActivity"
             android:exported="true"
             android:screenOrientation="portrait">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
         tools:targetApi="31">
         <activity
             android:name=".presentation.article.ArticleActivity"
-            android:exported="true"
+            android:exported="false"
             android:screenOrientation="portrait" />
         <activity
             android:name=".presentation.MainActivity"

--- a/app/src/main/java/com/example/longdroid/presentation/MainActivity.kt
+++ b/app/src/main/java/com/example/longdroid/presentation/MainActivity.kt
@@ -1,12 +1,12 @@
 package com.example.longdroid.presentation
 
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
 import com.example.longdroid.R
+import com.example.longdroid.databinding.ActivityMainBinding
+import com.example.longdroid.util.binding.BindingActivity
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main) {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
     }
 }

--- a/app/src/main/java/com/example/longdroid/presentation/article/ArticleActivity.kt
+++ b/app/src/main/java/com/example/longdroid/presentation/article/ArticleActivity.kt
@@ -1,12 +1,40 @@
 package com.example.longdroid.presentation.article
 
 import android.os.Bundle
+import androidx.activity.viewModels
 import com.example.longdroid.R
 import com.example.longdroid.databinding.ActivityArticleBinding
 import com.example.longdroid.util.binding.BindingActivity
+import com.example.longdroid.util.extension.setOnSingleClickListener
 
 class ArticleActivity : BindingActivity<ActivityArticleBinding>(R.layout.activity_article) {
+    private val articleViewModel: ArticlelViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        observeBookmark()
+        updateBookmarkState()
+    }
+
+    private fun updateBookmarkState() {
+        binding.ivArticleBookmark.setOnSingleClickListener {
+            articleViewModel.setBookMarkState()
+        }
+    }
+
+    private fun observeBookmark() {
+        articleViewModel.isBookMarked.observe(this) { isBookMarked ->
+            updateBookmarkUI(isBookMarked)
+        }
+    }
+
+    private fun updateBookmarkUI(isBookMarked: Boolean) {
+        val bookMark = if (isBookMarked) {
+            R.drawable.ic_book_mark_on_small
+        } else {
+            R.drawable.ic_book_mark_off_small
+        }
+        binding.ivArticleBookmark.setImageResource(bookMark)
     }
 }

--- a/app/src/main/java/com/example/longdroid/presentation/article/ArticleActivity.kt
+++ b/app/src/main/java/com/example/longdroid/presentation/article/ArticleActivity.kt
@@ -1,12 +1,12 @@
 package com.example.longdroid.presentation.article
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import com.example.longdroid.R
+import com.example.longdroid.databinding.ActivityArticleBinding
+import com.example.longdroid.util.binding.BindingActivity
 
-class ArticleActivity : AppCompatActivity() {
+class ArticleActivity : BindingActivity<ActivityArticleBinding>(R.layout.activity_article) {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_article)
     }
 }

--- a/app/src/main/java/com/example/longdroid/presentation/article/ArticleActivity.kt
+++ b/app/src/main/java/com/example/longdroid/presentation/article/ArticleActivity.kt
@@ -2,6 +2,7 @@ package com.example.longdroid.presentation.article
 
 import android.os.Bundle
 import androidx.activity.viewModels
+import androidx.core.content.ContextCompat
 import com.example.longdroid.R
 import com.example.longdroid.databinding.ActivityArticleBinding
 import com.example.longdroid.util.binding.BindingActivity
@@ -13,28 +14,57 @@ class ArticleActivity : BindingActivity<ActivityArticleBinding>(R.layout.activit
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        observeBookmark()
-        updateBookmarkState()
+        observeLike()
+        observeBookMark()
+        setupClickListeners()
     }
 
-    private fun updateBookmarkState() {
-        binding.ivArticleBookmark.setOnSingleClickListener {
-            articleViewModel.setBookMarkState()
+    private fun setupClickListeners() {
+        with(binding) {
+            ivArticleLike.setOnSingleClickListener {
+                articleViewModel.setLikeState()
+            }
+            ivArticleReadMark.setOnSingleClickListener {
+                setTransparentBackground()
+
+                // TODO 나중에 어댑터에서 문단 클릭 이벤트 처리 이후로 옴길 예정
+                // articleViewModel.setBookMarkState()
+            }
         }
     }
 
-    private fun observeBookmark() {
-        articleViewModel.isBookMarked.observe(this) { isBookMarked ->
-            updateBookmarkUI(isBookMarked)
+    private fun setTransparentBackground() {
+        binding.clArticleBody.foreground =
+            ContextCompat.getDrawable(this, R.color.transparent_background)
+    }
+
+    private fun observeBookMark() {
+        articleViewModel.isBookMarked.observe(this) { isBookMark ->
+            updateBookMarkUI(isBookMark)
         }
     }
 
-    private fun updateBookmarkUI(isBookMarked: Boolean) {
-        val bookMark = if (isBookMarked) {
+    private fun observeLike() {
+        articleViewModel.isLike.observe(this) { isArticleLike ->
+            updateLikeUI(isArticleLike)
+        }
+    }
+
+    private fun updateLikeUI(isLike: Boolean) {
+        val likeImage = if (isLike) {
             R.drawable.ic_book_mark_on_small
         } else {
             R.drawable.ic_book_mark_off_small
         }
-        binding.ivArticleBookmark.setImageResource(bookMark)
+        binding.ivArticleLike.setImageResource(likeImage)
+    }
+
+    private fun updateBookMarkUI(isBookMark: Boolean) {
+        val bookMarkImage = if (isBookMark) {
+            R.drawable.ic_btn_delete_read_mark
+        } else {
+            R.drawable.ic_btn_add_read_mark
+        }
+        binding.ivArticleReadMark.setImageResource(bookMarkImage)
     }
 }

--- a/app/src/main/java/com/example/longdroid/presentation/article/ArticleActivity.kt
+++ b/app/src/main/java/com/example/longdroid/presentation/article/ArticleActivity.kt
@@ -3,6 +3,7 @@ package com.example.longdroid.presentation.article
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.core.content.ContextCompat
+import coil.load
 import com.example.longdroid.R
 import com.example.longdroid.databinding.ActivityArticleBinding
 import com.example.longdroid.util.binding.BindingActivity
@@ -56,7 +57,7 @@ class ArticleActivity : BindingActivity<ActivityArticleBinding>(R.layout.activit
         } else {
             R.drawable.ic_book_mark_off_small
         }
-        binding.ivArticleLike.setImageResource(likeImage)
+        binding.ivArticleLike.load(likeImage)
     }
 
     private fun updateBookMarkUI(isBookMark: Boolean) {
@@ -65,6 +66,6 @@ class ArticleActivity : BindingActivity<ActivityArticleBinding>(R.layout.activit
         } else {
             R.drawable.ic_btn_add_read_mark
         }
-        binding.ivArticleReadMark.setImageResource(bookMarkImage)
+        binding.ivArticleReadMark.load(bookMarkImage)
     }
 }

--- a/app/src/main/java/com/example/longdroid/presentation/article/ArticleActivity.kt
+++ b/app/src/main/java/com/example/longdroid/presentation/article/ArticleActivity.kt
@@ -1,0 +1,12 @@
+package com.example.longdroid.presentation.article
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import com.example.longdroid.R
+
+class ArticleActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_article)
+    }
+}

--- a/app/src/main/java/com/example/longdroid/presentation/article/ArticlelViewModel.kt
+++ b/app/src/main/java/com/example/longdroid/presentation/article/ArticlelViewModel.kt
@@ -1,0 +1,15 @@
+package com.example.longdroid.presentation.article
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+
+class ArticlelViewModel() : ViewModel() {
+
+    private val _isBookMarked = MutableLiveData(false)
+    val isBookMarked: LiveData<Boolean> get() = _isBookMarked
+
+    fun setBookMarkState() {
+        _isBookMarked.value = _isBookMarked.value?.not()
+    }
+}

--- a/app/src/main/java/com/example/longdroid/presentation/article/ArticlelViewModel.kt
+++ b/app/src/main/java/com/example/longdroid/presentation/article/ArticlelViewModel.kt
@@ -9,6 +9,20 @@ class ArticlelViewModel() : ViewModel() {
     private val _isBookMarked = MutableLiveData(false)
     val isBookMarked: LiveData<Boolean> get() = _isBookMarked
 
+    private val _isStamp = MutableLiveData(false)
+    val isStamp: LiveData<Boolean> get() = _isStamp
+
+    private val _isLike = MutableLiveData(false)
+    val isLike: LiveData<Boolean> get() = _isLike
+
+    fun setLikeState() {
+        _isLike.value = _isLike.value?.not()
+    }
+
+    fun setStampState() {
+        _isStamp.value = _isStamp.value?.not()
+    }
+
     fun setBookMarkState() {
         _isBookMarked.value = _isBookMarked.value?.not()
     }

--- a/app/src/main/res/drawable/ic_arrow_left_white.xml
+++ b/app/src/main/res/drawable/ic_arrow_left_white.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="9dp"
+    android:height="14dp"
+    android:viewportWidth="9"
+    android:viewportHeight="14">
+  <path
+      android:pathData="M8,1L2,7L8,13"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#ECECEC"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/selector_book_mark_background.xml
+++ b/app/src/main/res/drawable/selector_book_mark_background.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Enabled state -->
+    <item android:state_enabled="true" android:drawable="@drawable/ic_book_mark_on_small" />
+
+    <!-- Disabled state -->
+    <item android:state_enabled="false" android:drawable="@drawable/ic_book_mark_off_small" />
+</selector>

--- a/app/src/main/res/drawable/selector_book_mark_background.xml
+++ b/app/src/main/res/drawable/selector_book_mark_background.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <!-- Enabled state -->
-    <item android:state_enabled="true" android:drawable="@drawable/ic_book_mark_on_small" />
-
-    <!-- Disabled state -->
-    <item android:state_enabled="false" android:drawable="@drawable/ic_book_mark_off_small" />
-</selector>

--- a/app/src/main/res/layout/activity_article.xml
+++ b/app/src/main/res/layout/activity_article.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".presentation.article.ArticleActivity">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_article.xml
+++ b/app/src/main/res/layout/activity_article.xml
@@ -38,7 +38,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="20dp"
-                android:background="@drawable/ic_book_mark_off_small"
+                android:src="@drawable/ic_book_mark_off_small"
                 app:layout_constraintBottom_toBottomOf="@id/iv_article_back"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="@id/iv_article_back" />

--- a/app/src/main/res/layout/activity_article.xml
+++ b/app/src/main/res/layout/activity_article.xml
@@ -10,8 +10,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/cl_article"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="#73141414">
+        android:layout_height="match_parent">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/cl_article_app_bar"
@@ -47,15 +46,17 @@
         </androidx.constraintlayout.widget.ConstraintLayout>
 
         <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_article_body"
             android:layout_width="match_parent"
             android:layout_height="0dp"
+            android:foreground="@color/transparent_background"
+            app:layout_constraintBottom_toTopOf="@id/cl_article_bottom_bar"
             app:layout_constraintTop_toBottomOf="@id/cl_article_app_bar">
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/rv_article_title"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="48dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"

--- a/app/src/main/res/layout/activity_article.xml
+++ b/app/src/main/res/layout/activity_article.xml
@@ -1,9 +1,51 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".presentation.article.ArticleActivity">
+    xmlns:tools="http://schemas.android.com/tools">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".presentation.article.ArticleActivity">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_article_app_bar"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:background="@color/sub_g1"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageView
+                android:id="@+id/iv_article_back"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="30dp"
+                android:layout_marginTop="21dp"
+                android:layout_marginBottom="19dp"
+                android:src="@drawable/ic_arrow_left_white"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <ImageButton
+                android:id="@+id/iv_article_bookmark"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="20dp"
+                android:background="@drawable/selector_book_mark_background"
+                android:enabled="false"
+                app:layout_constraintBottom_toBottomOf="@id/iv_article_back"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@id/iv_article_back" />
+
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/activity_article.xml
+++ b/app/src/main/res/layout/activity_article.xml
@@ -34,7 +34,7 @@
                 app:layout_constraintTop_toTopOf="parent" />
 
             <ImageView
-                android:id="@+id/iv_article_bookmark"
+                android:id="@+id/iv_article_like"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="20dp"
@@ -49,7 +49,6 @@
             android:id="@+id/cl_article_body"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            android:foreground="@color/transparent_background"
             app:layout_constraintBottom_toTopOf="@id/cl_article_bottom_bar"
             app:layout_constraintTop_toBottomOf="@id/cl_article_app_bar">
 

--- a/app/src/main/res/layout/activity_article.xml
+++ b/app/src/main/res/layout/activity_article.xml
@@ -8,9 +8,10 @@
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/cl_article"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".presentation.article.ArticleActivity">
+        android:background="#73141414">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/cl_article_app_bar"
@@ -33,19 +34,85 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
-            <ImageButton
+            <ImageView
                 android:id="@+id/iv_article_bookmark"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="20dp"
-                android:background="@drawable/selector_book_mark_background"
-                android:enabled="false"
+                android:background="@drawable/ic_book_mark_off_small"
                 app:layout_constraintBottom_toBottomOf="@id/iv_article_back"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="@id/iv_article_back" />
 
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintTop_toBottomOf="@id/cl_article_app_bar">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_article_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="48dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:listitem="@layout/item_article_title" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_article_main"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="40dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/rv_article_title" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_article_bottom_bar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/white"
+            app:layout_constraintBottom_toBottomOf="parent">
+
+            <ImageView
+                android:id="@+id/iv_article_read_mark"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="10dp"
+                android:layout_marginBottom="31dp"
+                android:src="@drawable/ic_btn_add_read_mark"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <ImageView
+                android:id="@+id/iv_article_left"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="40dp"
+                android:src="@drawable/ic_arrow_left_small"
+                app:layout_constraintBottom_toBottomOf="@id/iv_article_read_mark"
+                app:layout_constraintEnd_toStartOf="@id/iv_article_right"
+                app:layout_constraintTop_toTopOf="@id/iv_article_read_mark" />
+
+            <ImageView
+                android:id="@+id/iv_article_right"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="20dp"
+                android:src="@drawable/ic_arrow_right_small"
+                app:layout_constraintBottom_toBottomOf="@id/iv_article_left"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@id/iv_article_left" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
+
 </layout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,18 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".presentation.MainActivity">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Hello World!"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+    <data>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".presentation.MainActivity">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Hello World!"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/item_article_main.xml
+++ b/app/src/main/res/layout/item_article_main.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/gl_start"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_begin="20dp" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/gl_end"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_end="20dp" />
+
+    <TextView
+        android:id="@+id/tv_article_subtitle"
+        style="@style/H6_Bold"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:lineSpacingExtra="6dp"
+        android:textColor="@color/sub_g1"
+        app:layout_constraintStart_toStartOf="@id/gl_start"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="롱블랙 프렌즈 L" />
+
+    <TextView
+        android:id="@+id/tv_article_main"
+        style="@style/B1_Regular"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="22dp"
+        android:lineSpacingExtra="10dp"
+        android:textColor="@color/sub_g1"
+        app:layout_constraintStart_toStartOf="@id/gl_start"
+        app:layout_constraintTop_toBottomOf="@id/tv_article_subtitle"
+        tools:text="얼마 전 B네 집에 놀러갔는데, 거실에 못 보던\n그림이 걸려있더라. 물감 결이 살아있는 걸" />
+
+    <TextView
+        android:id="@+id/tv_article_main_last"
+        style="@style/B1_Regular"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:lineSpacingExtra="10dp"
+        android:textColor="@color/sub_g1"
+        app:layout_constraintStart_toStartOf="@id/gl_start"
+        app:layout_constraintTop_toBottomOf="@id/tv_article_main"
+        tools:text="보니 원화였어.\n\n" />
+
+    <ImageView
+        android:id="@+id/iv_article_read_mark"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:src="@drawable/ic_read_mark"
+        android:visibility="gone"
+        app:layout_constraintStart_toEndOf="@+id/tv_article_main_last"
+        app:layout_constraintTop_toTopOf="@+id/tv_article_main_last" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_article_title.xml
+++ b/app/src/main/res/layout/item_article_title.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/gl_start"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_begin="20dp" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/gl_end"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_end="20dp" />
+
+    <View
+        android:id="@+id/view_article_top"
+        android:layout_width="0dp"
+        android:layout_height="4dp"
+        android:background="@color/sub_g1"
+        app:layout_constraintEnd_toEndOf="@id/gl_end"
+        app:layout_constraintStart_toStartOf="@id/gl_start"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/tv_article_title"
+        style="@style/H2_Bold"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="28dp"
+        android:lineSpacingExtra="6dp"
+        android:textColor="@color/sub_g1"
+        app:layout_constraintStart_toStartOf="@id/view_article_top"
+        app:layout_constraintTop_toBottomOf="@id/view_article_top"
+        tools:text="오픈갤러리 : 내 거실이\n갤러리, 미술 시장의\n빈틈을 파고든 원화 구독\n서비스" />
+
+    <ImageView
+        android:id="@+id/iv_article_coffee"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:src="@drawable/ic_coffee_sticker_off_big"
+        app:layout_constraintBottom_toTopOf="@+id/view_article_bottom"
+        app:layout_constraintEnd_toEndOf="@id/gl_end" />
+
+
+    <TextView
+        android:id="@+id/tv_article_author"
+        style="@style/B6_Regular"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="52dp"
+        android:textColor="@color/sub_g1"
+        app:layout_constraintStart_toStartOf="@id/gl_start"
+        app:layout_constraintTop_toBottomOf="@id/tv_article_title"
+        tools:text="박시원" />
+
+    <View
+        android:id="@+id/view_article_small"
+        android:layout_width="1dp"
+        android:layout_height="12dp"
+        android:layout_marginStart="12dp"
+        android:background="@color/sub_g4"
+        app:layout_constraintBottom_toBottomOf="@id/tv_article_author"
+        app:layout_constraintEnd_toStartOf="@id/tv_article_category"
+        app:layout_constraintStart_toEndOf="@id/tv_article_author"
+        app:layout_constraintTop_toTopOf="@id/tv_article_author" />
+
+    <TextView
+        android:id="@+id/tv_article_category"
+        style="@style/B3_Medium"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:textColor="@color/sand"
+        app:layout_constraintBottom_toBottomOf="@id/view_article_small"
+        app:layout_constraintStart_toEndOf="@id/view_article_small"
+        app:layout_constraintTop_toTopOf="@id/view_article_small"
+        tools:text="B" />
+
+
+    <TextView
+        android:id="@+id/tv_article_date"
+        style="@style/B6_Regular"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="29dp"
+        android:textColor="@color/sub_g1"
+        app:layout_constraintBottom_toBottomOf="@id/tv_article_category"
+        app:layout_constraintStart_toEndOf="@id/tv_article_category"
+        app:layout_constraintTop_toTopOf="@id/tv_article_category"
+        tools:text="2023.11.09" />
+
+    <View
+        android:id="@+id/view_article_bottom"
+        android:layout_width="0dp"
+        android:layout_height="2dp"
+        android:layout_marginHorizontal="20dp"
+        android:layout_marginTop="8dp"
+        android:background="@color/sub_g1"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_article_author" />
+
+    <ImageView
+        android:id="@+id/iv_article_author"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="44dp"
+        android:src="@drawable/img_article_profile"
+        app:layout_constraintStart_toStartOf="@id/gl_start"
+        app:layout_constraintTop_toBottomOf="@id/view_article_bottom" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_article_title.xml
+++ b/app/src/main/res/layout/item_article_title.xml
@@ -23,6 +23,7 @@
         android:id="@+id/view_article_top"
         android:layout_width="0dp"
         android:layout_height="4dp"
+        android:layout_marginTop="40dp"
         android:background="@color/sub_g1"
         app:layout_constraintEnd_toEndOf="@id/gl_end"
         app:layout_constraintStart_toStartOf="@id/gl_start"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -20,4 +20,5 @@
     <color name="green">#A4F4A4</color>
     <color name="red">#FF5126</color>
     <color name="orange">#2EFF6543</color>
+    <color name="transparent_background">#73141414</color>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -2,7 +2,7 @@
     <!-- Base application theme. -->
     <style name="Base.Theme.LongDroid" parent="Theme.Material3.Light.NoActionBar">
         <!-- Status bar color. -->
-        // TODO 컬러시스템 추가후 statusbar 색 변경 추가
+        <item name="android:statusBarColor">@color/sub_g1</item>
         <item name="android:windowLightStatusBar">true</item>
         <!-- Customize your theme here. -->
         <item name="android:includeFontPadding">false</item>


### PR DESCRIPTION
## 📌 관련 이슈
-  closed #10 

## 📷 screenshot
<!-- 시연영상을 업로드해주세요. -->

https://github.com/DO-SOPT-33rd-CDS-1/LongBlack_Android/assets/113578158/ea5111af-068e-443f-a782-bf731ef48f6c


## 📝 Work Desciption
<!-- 작업한 내용을 설명해주세요. -->
- 아티클 뷰작업 
- 상태변경

## 📚 Reference 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
뷰작업 끝냈고, 더미데이터 넣어서 하려다 (귀찮음 이슈로) 그냥 서버 바로 붙이겠습니다.
멀티뷰 타입으로 아티클 구현할 예정이고, 책갈피는 미리 박아두고 해당 문단 누르면 visible 처리로 해줄겁니다 (줄바꿈은 flexboxmanager 사용)
책갈피 상태 저장하는것도 할것 같습니다. 그래서 서버가 빨리 배포되었으면 하네요...